### PR TITLE
Fix sidebar active selection indicators

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -509,7 +509,9 @@ const App: React.FC = () => {
           collections={collections}
           rootRequests={rootRequests}
           tabs={tabs}
-          activeRequestId={activeTabId}
+          activeRequestId={activeTab?.type === 'request' ? activeTabId : undefined}
+          activeCapturedId={activeTab?.type === 'request' ? activeTabId : undefined}
+          activeMockRuleId={activeTab?.type === 'mock' ? activeTabId : undefined}
           onSelectRequest={openRequestInTab}
           onCreateCollection={() => { const newCol = { id: generateId(), name: chrome.i18n.getMessage("newCollection"), requests: [], collapsed: false }; const next = [...collections, newCol]; setCollections(next); chrome.storage.local.set({ collections: next }); setSidebarTab('collections'); }}
           onCreateRequest={handleCreateRequest}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -17,6 +17,8 @@ interface SidebarProps {
   rootRequests: HttpRequest[];
   tabs: TabItem[];
   activeRequestId?: string;
+  activeCapturedId?: string;
+  activeMockRuleId?: string;
   onSelectRequest: (req: HttpRequest) => void;
   onCreateCollection: () => void;
   onCreateRequest: () => void;
@@ -67,7 +69,7 @@ const copyToClipboard = (text: string): boolean => {
 };
 
 export const Sidebar: React.FC<SidebarProps> = ({
-  activeTab, onTabChange, history, onImportLoggedRequest, collections, rootRequests, tabs, activeRequestId, onSelectRequest, onCreateCollection, onCreateRequest, onImportCurl, onClearHistory, onDeleteLog, onRenameCollection, onRenameRequest, onDeleteCollection, onDeleteRequest, onDuplicateRequest, onToggleCollapse, onMoveRequest, isRecording, onToggleRecording, onCollapseSidebar, onResetAllData, language, onLanguageChange,
+  activeTab, onTabChange, history, onImportLoggedRequest, collections, rootRequests, tabs, activeRequestId, activeCapturedId, activeMockRuleId, onSelectRequest, onCreateCollection, onCreateRequest, onImportCurl, onClearHistory, onDeleteLog, onRenameCollection, onRenameRequest, onDeleteCollection, onDeleteRequest, onDuplicateRequest, onToggleCollapse, onMoveRequest, isRecording, onToggleRecording, onCollapseSidebar, onResetAllData, language, onLanguageChange,
   mockRules, mockGlobalEnabled, onSelectMockRule, onCreateMockRule, onToggleMockGlobal, onToggleMockRule, onDeleteMockRule, onDuplicateMockRule, onClearMockRules, onRenameMockRule, onMockFromLog
 }) => {
   const [contextMenu, setContextMenu] = useState<{ x: number, y: number, type: 'collection' | 'request' | 'log', id: string, data?: any } | null>(null);
@@ -269,7 +271,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <MockList
             rules={mockRules}
             globalEnabled={mockGlobalEnabled}
-            activeRuleId={activeRequestId}
+            activeRuleId={activeMockRuleId}
             onSelect={onSelectMockRule}
             onCreate={onCreateMockRule}
             onToggleGlobal={onToggleMockGlobal}
@@ -310,7 +312,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
              </div>
              {filteredHistory.map(item => {
                  const { origin, path } = formatUrl(item.url);
-                 const isActive = activeRequestId === item.id;
+                 const isActive = activeCapturedId === item.id;
                  return (
                    <ListItem
                      key={item.id}


### PR DESCRIPTION
### Motivation
- Captured requests and mock rules were reusing a single ambiguous active ID which caused inconsistent left-border active styling across the sidebar lists. 
- The goal is to make captured list and mock list selection behave the same as collection request rows so the green active indicator appears for the correct row.

### Description
- Add two list-specific props to `Sidebar`: `activeCapturedId` and `activeMockRuleId` so each list can determine its own active row. 
- In `App.tsx` pass `activeCapturedId={activeTab?.type === 'request' ? activeTabId : undefined}` and `activeMockRuleId={activeTab?.type === 'mock' ? activeTabId : undefined}` so the active ID is selected by current tab type. 
- Use `activeMockRuleId` when creating the `MockList` and use `activeCapturedId` when checking `isActive` for the captured history rows so each list renders the green active left border consistently. 
- Changes applied to `App.tsx` and `components/Sidebar.tsx` to implement the above wiring.

### Testing
- Ran the production build with `npm run build`, which completed successfully and produced the `dist/` output. 
- Attempted `npm test` but the project has no `test` script, so no unit tests were executed. 
- Manual verification: sidebar captured list and mock list now highlight the selected row with the same green active styling as collection rows when the corresponding tab is active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac233d3e8832ca5c784016161ac13)